### PR TITLE
Fix inline message persistence on editor switch and refactor codes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import InlineMessageController from './components/InlineMessageController';
 import WebviewController from './components/webview/WebviewController';
 import { runGitBlameCommand } from './services/git';
 import { getJiraIssueKey } from './services/jira';
+import { delay } from './utils';
 
 export function activate(context: vscode.ExtensionContext): void {
   new Extension(context);
@@ -15,7 +16,24 @@ export function activate(context: vscode.ExtensionContext): void {
 
 function bindEventListeners(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor(onChange),
+    /**
+     * onDidChangeActiveTextEditor    - change of editor
+     * onDidChangeTextEditorSelection - change of selection
+     * onDidChangeTextDocument        - change of content
+     *
+     * After file A line 1 -> file B:
+     * 1. file B -> file A line 1     - trigger change of editor
+     * 2. file B -> file A line 2     - trigger change of editor and selection
+     */
+    vscode.window.onDidChangeActiveTextEditor(async () => {
+      /**
+       * This could be triggered before the active line gets updated. Then, the git blame command
+       * will run against a wrong line number and cause inline message to render incorrectly. To
+       * avoid that, wait for a short period of time before requesting the information.
+       */
+      await delay(50);
+      onChange();
+    }),
     vscode.window.onDidChangeTextEditorSelection(onChange),
     vscode.workspace.onDidChangeTextDocument(onChange)
   );
@@ -27,23 +45,21 @@ function onChange(): void {
   const webviewController = WebviewController.getInstance();
   runGitBlameCommand()
     .then(async (gitBlameCommandInfo) => {
-      if (gitBlameCommandInfo) {
-        const commitMessage = gitBlameCommandInfo.gitBlameInfo.summary;
-        const jiraIssueKey = getJiraIssueKey(commitMessage);
-        statusBarItemController.renderStatusBarItem(jiraIssueKey);
-        inlineMessageController.renderInlineMessage(
-          gitBlameCommandInfo,
-          jiraIssueKey
-        );
-        webviewController.renderWebview(jiraIssueKey);
-      } else {
-        statusBarItemController.hideStatusBarItem();
-        inlineMessageController.hideInlineMessage();
-        webviewController.renderWebview('');
+      if (!gitBlameCommandInfo) {
+        throw new Error('gitBlameCommandInfo is undefiend.');
       }
+      const commitMessage = gitBlameCommandInfo.gitBlameInfo.summary;
+      const jiraIssueKey = getJiraIssueKey(commitMessage);
+      // The no-Jira-issue-key situation is handled within rendering functions
+      statusBarItemController.renderStatusBarItem(jiraIssueKey);
+      inlineMessageController.renderInlineMessage(
+        gitBlameCommandInfo,
+        jiraIssueKey
+      );
+      webviewController.renderWebview(jiraIssueKey);
     })
     .catch((error) => {
-      console.error('runGitBlameCommand error: ', error.message);
+      console.error('runGitBlameCommand error:', error.message);
       statusBarItemController.hideStatusBarItem();
       inlineMessageController.hideInlineMessage();
       webviewController.renderWebview('');

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -20,19 +20,19 @@ function parseGitBlameResponse(blame: string): GitBlameInfo {
 export async function runGitBlameCommand(): Promise<
   GitBlameCommandInfo | undefined
 > {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor) {
     return;
   }
-  const currentFile = editor.document.uri;
-  const lineNumber = editor.selection.active.line;
+  const activeFile = activeEditor.document.uri;
+  const activeLineNumber = activeEditor.selection.active.line;
   const commandArguments = [
     'blame',
     '--porcelain',
-    `-L${lineNumber + 1},+1`,
-    currentFile.fsPath
+    `-L${activeLineNumber + 1},+1`,
+    activeFile.fsPath
   ];
-  const workspaceFolder = vscode.workspace.getWorkspaceFolder(currentFile);
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(activeFile);
   if (!workspaceFolder) {
     return;
   }
@@ -42,7 +42,11 @@ export async function runGitBlameCommand(): Promise<
     const gitBlameCommand = cp.spawn('git', commandArguments, commandOptions);
     gitBlameCommand.stdout.on('data', (response) => {
       const gitBlameInfo = parseGitBlameResponse(response.toString());
-      resolve({ gitBlameInfo, editor, lineNumber });
+      resolve({
+        gitBlameInfo,
+        editor: activeEditor,
+        lineNumber: activeLineNumber
+      });
     });
     gitBlameCommand.stderr.on('error', (error) => {
       reject(error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export function isValidUrl(url: string): boolean {
   try {
     new URL(url);


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->
When `onDidChangeActiveTextEditor` gets triggered, the active line might not be updated yet, and the inline message will be rendered using the wrong line number. This PR addresses the issue by:

1. Improve the logic in `renderInlineMessage()`
2. When `onDidChangeActiveTextEditor` gets triggered, pause for a short period before running `onChange()`

This PR also includes a minor refactor of codes outside the scope.

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->
1. While switching the active editor, the inline message in the previous editor could persist, which was obvious when putting editors side by side.
2. From `file A line 1` to `file B` to `file A line 2`, the final line being rendered in `file A` could be either `line 1` or `line 2`, and there is a flickering effect (inline message appear at `line 1` then suddenly change to `line 2`).

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->
There will be a maximum of one inline message at any time. The line to render after revisiting an opened file is stably correct.

# Checklist

- [X] No commit includes credentials or sensitive information
- [X] Changes have been tested locally
- [X] Relevant documentations have been updated, or documentation updates are not applicable for this change
