### PR TITLE
Disable inline commit message by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         },
         "jiralens.inlineCommitMessage": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Show the commit message in inline message."
         }
       }


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->
The inline commit message is not helpful as it is usually truncated (the truncation was done on purpose to avoid the whole inline message being too long). Besides, since the hover modal is not displaying the commit message as well, users might feel annoyed for having no approach from us to get the full commit message while part of the commit message always shows up.

IMO, JiraLens should focus on displaying Jira information instead of Git information. Therefore, I changed the default behavior to not include the commit message in inline messages.

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->

# Checklist

- [x] No commit includes credentials or sensitive information
- [x] Changes have been tested locally
- [x] Relevant documentations have been updated, or documentation updates are not applicable for this change
