### PR TITLE
Fix the webview list display issue and remove bottom issue link

### DIFF
--- a/media/webview.css
+++ b/media/webview.css
@@ -5,7 +5,6 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
     Ubuntu, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  padding-bottom: 2rem;
 }
 
 .header {
@@ -15,6 +14,29 @@ body {
   flex-direction: row;
   align-items: center;
 }
+h3 {
+  margin-bottom: 5px;
+}
+
+table {
+  border-collapse: collapse;
+}
+table,
+th,
+td {
+  border: 1px solid white;
+  padding: 8px;
+}
+
+ul {
+  padding-left: 14px;
+}
+ol {
+  margin-left: 15px;
+}
+
+/* ---------- Custom Tags ---------- */
+/* Summary */
 #project-avatar {
   width: 48px;
   height: 48px;
@@ -24,19 +46,13 @@ body {
   margin-left: 10px;
   flex-direction: column;
 }
-h3 {
-  margin-bottom: 5px;
-}
 
+/* Details */
 #issue-details {
   margin-top: 0.5rem;
   display: flex;
   flex-direction: row;
   margin-bottom: 1rem;
-}
-#priority-icon {
-  width: 12px;
-  height: 12px;
 }
 #issue-details-keys {
   display: flex;
@@ -47,7 +63,12 @@ h3 {
   display: flex;
   flex-direction: column;
 }
+#priority-icon {
+  width: 12px;
+  height: 12px;
+}
 
+/* Profiles */
 #profiles {
   margin-top: 0.5rem;
 }
@@ -62,30 +83,20 @@ h3 {
   margin-right: 10px;
 }
 
+/* Description */
 #issue-description {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
+
+/* Attachments */
 #attachments {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
+
+/* Comments */
 #comments {
   margin-top: 1rem;
   margin-bottom: 1rem;
-}
-table {
-  border-collapse: collapse;
-}
-table,
-th,
-td {
-  border: 1px solid white;
-  padding: 8px;
-}
-#external-link {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }

--- a/src/components/webview/WebviewViewProvider.ts
+++ b/src/components/webview/WebviewViewProvider.ts
@@ -263,7 +263,6 @@ export default class WebviewViewProvider implements vscode.WebviewViewProvider {
               .join('')}
           </table>
         </div>
-        <a id="external-link" href="${jiraIssueLink}">Open in Browser</a>
       </body>
     </html>`;
   }


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->
Previously list markers (`::marker`) are outside the text block. In tables, these markers overlap with cell borders. There are multiple solutions for this issue.

One way is using:
```
ul,
ol {
  list-style-position: inside;
}

p {
  display: inline;
}
```

However, as `<p>` affects many other places, this approach was not used. Instead, the issue was solved by putting left margins for list tags.

Besides, this PR removes the `Open in Browser` component at the bottom of the webview since the summary section already contains a link to the issue.

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->
List markers are outside the text block.

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->
List markers are inside the text block, note that it's different from the CSS `list-style-position: inside;`.

# Checklist

- [X] No commit includes credentials or sensitive information
- [X] Changes have been tested locally
- [X] Relevant documentations have been updated, or documentation updates are not applicable for this change
