### PR TITLE
Suppress errors to avoid alarming users unnecessarily

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,10 @@ function onChange(): void {
   runGitBlameCommand()
     .then(async (gitBlameCommandInfo) => {
       if (!gitBlameCommandInfo) {
-        throw new Error('gitBlameCommandInfo is undefined.');
+        statusBarItemController.hideStatusBarItem();
+        inlineMessageController.hideInlineMessage();
+        webviewController.renderWebview('');
+        return;
       }
       const commitMessage = gitBlameCommandInfo.gitBlameInfo.summary;
       const jiraIssueKey = getJiraIssueKey(commitMessage);
@@ -61,7 +64,7 @@ function onChange(): void {
       webviewController.renderWebview(jiraIssueKey);
     })
     .catch((error) => {
-      console.error('runGitBlameCommand error:', error.message);
+      console.debug('runGitBlameCommand error:', error.message);
       statusBarItemController.hideStatusBarItem();
       inlineMessageController.hideInlineMessage();
       webviewController.renderWebview('');


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->
While updating the extension, users can see the number of error logs from this extension. Previously I thought there was no harm in letting the error be thrown for debugging purposes (some error logs are not from "real" errors). However, considering this might affect users' trust in JiraLens, I decided to suppress these errors to avoid alarming our users unnecessarily.

This PR also implements the default message when the current logic fails to convert a Jira markdown for display.

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->

# Checklist

- [X] No commit includes credentials or sensitive information
- [X] Changes have been tested locally
- [X] Relevant documentations have been updated, or documentation updates are not applicable for this change
