### PR TITLE
ci: change the token name used for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,5 +22,5 @@ jobs:
 
       - name: Semantic release
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: HUSKY=0 npx semantic-release


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->
According to [this documentation](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication), the semantic release GitHub plugin needs the token as `GH_TOKEN`, unlike others that can take either `GH_TOKEN` or `GITHUB_TOKEN`.

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->

# Checklist

- [X] No commit includes credentials or sensitive information
- [X] Changes have been tested locally
- [X] Relevant documentations have been updated, or documentation updates are not applicable for this change
