### PR TITLE
fix: register the correct command and handle undefined configs

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,6 +9,7 @@ import {
   setJiraHost,
   setShowInlineCommitMessage,
   setShowInlineCommitter,
+  setShowInlineJiraIssueKey,
   setShowInlineRelativeCommitTime
 } from './configs';
 import { isValidJiraBearerToken, isValidJiraProjectKey } from './services/jira';
@@ -148,7 +149,7 @@ function registerSetShowJiraIssueKeyCommand(): vscode.Disposable {
     if (!show) {
       return;
     }
-    setShowInlineCommitMessage(show === 'Yes');
+    setShowInlineJiraIssueKey(show === 'Yes');
   });
 }
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -44,7 +44,8 @@ export async function setJiraBearerToken(token: string): Promise<boolean> {
 
 // jiralens.jiraProjectKeys
 export function getJiraProjectKeys(): string[] {
-  return wsConfig.get('jiraProjectKeys') as string[];
+  const keys = (wsConfig.get('jiraProjectKeys') as string[]) ?? [];
+  return keys;
 }
 async function setJiraProjectKeys(keys: string[]): Promise<boolean> {
   try {
@@ -84,7 +85,7 @@ export async function deleteJiraProjectKey(key: string): Promise<boolean> {
 
 // jiralens.inlineCommitter
 export function getShowInlineCommitter(): boolean {
-  return wsConfig.get('inlineCommitter') as boolean;
+  return wsConfig.get('inlineCommitter') ?? true;
 }
 export async function setShowInlineCommitter(show: boolean): Promise<boolean> {
   try {
@@ -105,7 +106,7 @@ export async function setShowInlineCommitter(show: boolean): Promise<boolean> {
 
 // jiralens.inlineRelativeCommitTime
 export function getShowInlineRelativeCommitTime(): boolean {
-  return wsConfig.get('inlineRelativeCommitTime') as boolean;
+  return wsConfig.get('inlineRelativeCommitTime') ?? true;
 }
 export async function setShowInlineRelativeCommitTime(
   show: boolean
@@ -128,7 +129,7 @@ export async function setShowInlineRelativeCommitTime(
 
 // jiralens.inlineJiraIssueKey
 export function getShowInlineJiraIssueKey(): boolean {
-  return wsConfig.get('inlineJiraIssueKey') as boolean;
+  return wsConfig.get('inlineJiraIssueKey') ?? true;
 }
 export async function setShowInlineJiraIssueKey(
   show: boolean
@@ -151,7 +152,7 @@ export async function setShowInlineJiraIssueKey(
 
 // jiralens.inlineCommitMessage
 export function getShowInlineCommitMessage(): boolean {
-  return wsConfig.get('inlineCommitMessage') as boolean;
+  return wsConfig.get('inlineCommitMessage') ?? false;
 }
 export async function setShowInlineCommitMessage(
   show: boolean

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -12,7 +12,12 @@ export const window = {
   activeTextEditor: undefined,
   showErrorMessage: vi.fn(),
   showWarningMessage: vi.fn(),
-  showInformationMessage: vi.fn()
+  showInformationMessage: vi.fn(),
+  showQuickPick: vi.fn()
+};
+
+export const commands = {
+  registerCommand: vi.fn()
 };
 
 export const ConfigurationTarget = {

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { commands, window } from 'vscode';
+
+vi.mock('../../src/configs', () => ({
+  getJiraHost: vi.fn().mockReturnValue('jira.example.com'),
+  getJiraBearerToken: vi.fn().mockReturnValue('token'),
+  getJiraProjectKeys: vi.fn().mockReturnValue([]),
+  setJiraHost: vi.fn().mockResolvedValue(true),
+  setJiraBearerToken: vi.fn().mockResolvedValue(true),
+  addJiraProjectKey: vi.fn().mockResolvedValue(true),
+  deleteJiraProjectKey: vi.fn().mockResolvedValue(true),
+  setShowInlineCommitter: vi.fn().mockResolvedValue(true),
+  setShowInlineRelativeCommitTime: vi.fn().mockResolvedValue(true),
+  setShowInlineJiraIssueKey: vi.fn().mockResolvedValue(true),
+  setShowInlineCommitMessage: vi.fn().mockResolvedValue(true)
+}));
+
+vi.mock('../../src/services/jira', () => ({
+  isValidJiraBearerToken: vi.fn().mockReturnValue(true),
+  isValidJiraProjectKey: vi.fn().mockReturnValue(true)
+}));
+
+vi.mock('../../src/utils', () => ({
+  isValidUrl: vi.fn().mockReturnValue(true)
+}));
+
+// Import after mocks are set up
+const { default: registerCommands } = await import('../../src/commands');
+const { setShowInlineJiraIssueKey, setShowInlineCommitMessage } = await import(
+  '../../src/configs'
+);
+
+const mockContext = { subscriptions: { push: vi.fn() } } as any;
+
+// Capture command callbacks by ID when registerCommands is called
+const capturedCallbacks: Record<string, () => Promise<void>> = {};
+vi.mocked(commands.registerCommand).mockImplementation(
+  (id: string, cb: any) => {
+    capturedCallbacks[id] = cb;
+    return { dispose: vi.fn() };
+  }
+);
+
+registerCommands(mockContext);
+
+describe('registerSetShowJiraIssueKeyCommand', () => {
+  beforeEach(() => {
+    vi.mocked(setShowInlineJiraIssueKey).mockClear();
+    vi.mocked(setShowInlineCommitMessage).mockClear();
+  });
+
+  it('calls setShowInlineJiraIssueKey(true) when user picks Yes', async () => {
+    vi.mocked(window.showQuickPick).mockResolvedValue('Yes' as any);
+    await capturedCallbacks['jiralens.setShowJiraIssueKey']();
+    expect(setShowInlineJiraIssueKey).toHaveBeenCalledWith(true);
+    expect(setShowInlineCommitMessage).not.toHaveBeenCalled();
+  });
+
+  it('calls setShowInlineJiraIssueKey(false) when user picks No', async () => {
+    vi.mocked(window.showQuickPick).mockResolvedValue('No' as any);
+    await capturedCallbacks['jiralens.setShowJiraIssueKey']();
+    expect(setShowInlineJiraIssueKey).toHaveBeenCalledWith(false);
+    expect(setShowInlineCommitMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the user dismisses the picker', async () => {
+    vi.mocked(window.showQuickPick).mockResolvedValue(undefined as any);
+    await capturedCallbacks['jiralens.setShowJiraIssueKey']();
+    expect(setShowInlineJiraIssueKey).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/configs.test.ts
+++ b/test/unit/configs.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { workspace } from 'vscode';
+
+import {
+  getJiraProjectKeys,
+  getShowInlineCommitMessage,
+  getShowInlineCommitter,
+  getShowInlineJiraIssueKey,
+  getShowInlineRelativeCommitTime
+} from '../../src/configs';
+
+// wsConfig in configs.ts is initialised at module load via workspace.getConfiguration().
+// The mock always returns the same object, so we can reach its get() spy directly.
+const mockGet = vi.mocked(workspace.getConfiguration('jiralens').get);
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+describe('getJiraProjectKeys', () => {
+  it('returns the configured keys', () => {
+    mockGet.mockReturnValue(['PROJ', 'ABC']);
+    expect(getJiraProjectKeys()).toEqual(['PROJ', 'ABC']);
+  });
+
+  it('returns an empty array when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getJiraProjectKeys()).toEqual([]);
+  });
+});
+
+describe('getShowInlineCommitter', () => {
+  it('returns the configured value', () => {
+    mockGet.mockReturnValue(false);
+    expect(getShowInlineCommitter()).toBe(false);
+  });
+
+  it('returns true when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getShowInlineCommitter()).toBe(true);
+  });
+});
+
+describe('getShowInlineRelativeCommitTime', () => {
+  it('returns the configured value', () => {
+    mockGet.mockReturnValue(false);
+    expect(getShowInlineRelativeCommitTime()).toBe(false);
+  });
+
+  it('returns true when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getShowInlineRelativeCommitTime()).toBe(true);
+  });
+});
+
+describe('getShowInlineJiraIssueKey', () => {
+  it('returns the configured value', () => {
+    mockGet.mockReturnValue(false);
+    expect(getShowInlineJiraIssueKey()).toBe(false);
+  });
+
+  it('returns true when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getShowInlineJiraIssueKey()).toBe(true);
+  });
+});
+
+describe('getShowInlineCommitMessage', () => {
+  it('returns the configured value', () => {
+    mockGet.mockReturnValue(true);
+    expect(getShowInlineCommitMessage()).toBe(true);
+  });
+
+  it('returns false when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getShowInlineCommitMessage()).toBe(false);
+  });
+});


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->
Register the correct command and handle undefined configs (which only happens when the user clears the default config set in `package.json`).

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->

# Checklist

- [X] No commit includes credentials or sensitive information
- [X] Changes have been tested locally
- [X] Relevant documentations have been updated, or documentation updates are not applicable for this change
