### PR TITLE
fix: handle Jira Cloud authentication

### DIFF
--- a/.claude/commands/add-config.md
+++ b/.claude/commands/add-config.md
@@ -236,11 +236,13 @@ if (get<PascalKey>()) {
 ## 7. Documentation (MANDATORY for user-facing configs)
 
 ### `README.md`
+
 - Add or update a subsection under **Extension Setup**.
 - If a new command was added, list it in the **Comprehensive Commands** code block.
 - If the TOC needs a new entry, add it.
 
 ### `CLAUDE.md`
+
 - Add a row to the **Configuration Keys** table:
   ```
   | `<keyName>` | type | `<default>` | Description |

--- a/.claude/commands/add-config.md
+++ b/.claude/commands/add-config.md
@@ -1,0 +1,260 @@
+# Add or Update an Extension Configuration
+
+When adding or updating a `jiralens.*` configuration setting, work through the checklist below in order. Each section states whether it is mandatory or conditional.
+
+---
+
+## 1. `package.json` — configuration schema (MANDATORY)
+
+Add an entry under `contributes.configuration.properties`:
+
+```json
+"jiralens.<keyName>": {
+  "type": "string|boolean|array",
+  "default": <defaultValue>,
+  "description": "One-sentence user-facing description."
+}
+```
+
+For array types, also add `"items": { "type": "string" }`.
+
+---
+
+## 2. `src/configs.ts` — getter and setter (MANDATORY)
+
+Prefix the block with a comment line, then add two exported functions. Follow the existing style exactly.
+
+```typescript
+// jiralens.<keyName>
+export function get<PascalKey>(): Type {
+  return wsConfig.get<Type>('<keyName>') ?? <defaultValue>;
+}
+export async function set<PascalKey>(value: Type): Promise<boolean> {
+  try {
+    await wsConfig.update(
+      '<keyName>',
+      value,
+      vscode.ConfigurationTarget.Global
+    );
+    syncWorkspaceConfiguration();
+    return true;
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Failed to update the <description>: ${error}`
+    );
+    return false;
+  }
+}
+```
+
+**Nullish coalescing vs logical OR**: use `??` for all types. The only exception is `getJiraHost()`, which uses `||` because an empty-string host is equally invalid as a missing one — only replicate this pattern if empty string must be treated identically to `undefined`.
+
+**Always call `syncWorkspaceConfiguration()`** directly after `wsConfig.update()` to refresh the module-level cache.
+
+**Array-typed configs**: expose fine-grained helpers (`add…`, `delete…`) as the public API and keep the raw setter (`set<PascalKey>`) unexported. See `jiraProjectKeys` — `setJiraProjectKeys` is not exported; only `addJiraProjectKey` and `deleteJiraProjectKey` are.
+
+---
+
+## 3. `test/unit/configs.test.ts` — getter tests (MANDATORY)
+
+The file has a module-level `mockGet` constant and a module-level `beforeEach` that resets it — do not duplicate these; just add your `describe` block alongside the existing ones:
+
+```typescript
+// Already present at module level — do not add again:
+const mockGet = vi.mocked(workspace.getConfiguration('jiralens').get);
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+// Add your new describe block:
+describe('get<PascalKey>', () => {
+  it('returns the configured value', () => {
+    mockGet.mockReturnValue(<someValue>);
+    expect(get<PascalKey>()).toBe(<someValue>);
+  });
+
+  it('returns <defaultValue> when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(get<PascalKey>()).toBe(<defaultValue>);
+  });
+});
+```
+
+Also import the new getter alongside the existing imports at the top of the test file.
+
+---
+
+## 4. `package.json` commands + `src/commands.ts` (CONDITIONAL — if the config has a VS Code command)
+
+### 4a. `package.json` — add to `contributes.commands`
+
+```json
+{
+  "command": "jiralens.<commandId>",
+  "title": "<User-visible action title>"
+}
+```
+
+### 4b. `src/commands.ts` — register the command
+
+1. Add a constant at the top of the constants block: `const <COMMAND_CONST> = 'jiralens.<commandId>';`
+2. Add a `register<PascalKey>Command()` function. Use `showInputBox` for string/free-text configs, `showQuickPick(['Yes', 'No'])` for booleans.
+3. Push the function call inside `registerCommands()` → `context.subscriptions.push(…)`.
+4. Import the new getter/setter at the top of the file.
+
+**String config — empty string is invalid (most cases):**
+
+```typescript
+function register<PascalKey>Command(): vscode.Disposable {
+  return vscode.commands.registerCommand(<COMMAND_CONST>, async () => {
+    const input = await vscode.window.showInputBox({
+      prompt: 'Enter …',
+      placeHolder: '',
+      value: get<PascalKey>()
+    });
+    if (!input) return; // rejects both dismissal (undefined) and empty string
+    await set<PascalKey>(input);
+    vscode.window.showInformationMessage('Updated …');
+  });
+}
+```
+
+**String config — empty string is a valid value to save (e.g. clearing an optional field):**
+
+```typescript
+if (input === undefined) return; // dismissal only; empty string is intentional
+await set<PascalKey>(input);
+```
+
+**Pre-condition checks**: some commands must verify a prerequisite before showing the input. Place these at the top of the callback, before the `showInputBox` call:
+
+```typescript
+if (!getJiraHost()) {
+  vscode.window.showErrorMessage('Please set the Jira host first.');
+  return;
+}
+```
+
+**Input validation**: if the value must be validated before saving (e.g. URL format, token format, project key format), call the relevant validator from `src/services/jira.ts` or `src/utils.ts` and show an error on failure:
+
+```typescript
+if (!isValidSomething(input)) {
+  vscode.window.showErrorMessage('Invalid input.');
+  return;
+}
+```
+
+**Boolean config** — note: the setter is called without `await` (fire-and-forget), matching the existing pattern:
+
+```typescript
+function register<PascalKey>Command(): vscode.Disposable {
+  return vscode.commands.registerCommand(<COMMAND_CONST>, async () => {
+    const pick = await vscode.window.showQuickPick(['Yes', 'No'], {
+      placeHolder: '…?'
+    });
+    if (!pick) return;
+    set<PascalKey>(pick === 'Yes'); // no await — intentional
+  });
+}
+```
+
+### 4c. `test/unit/commands.test.ts` — command tests
+
+The test file uses dynamic ESM imports (mocks must be set up before the module loads). Follow this exact structure:
+
+1. Add `get<PascalKey>: vi.fn().mockReturnValue(<default>)` and `set<PascalKey>: vi.fn().mockResolvedValue(true)` to the `vi.mock('../../src/configs', …)` factory at the top.
+2. Add the getter and setter to the `await import('../../src/configs')` destructure below the mocks.
+3. Add a `describe` block that covers: happy path, dismissal (setter not called), and any validation/pre-condition branches specific to this command.
+
+```typescript
+// 1. In the vi.mock factory:
+vi.mock('../../src/configs', () => ({
+  // ... existing entries ...
+  get<PascalKey>: vi.fn().mockReturnValue(<default>),
+  set<PascalKey>: vi.fn().mockResolvedValue(true)
+}));
+
+// 2. In the await import destructure:
+const { set<PascalKey>, /* ...others */ } = await import('../../src/configs');
+
+// 3. describe block:
+describe('register<PascalKey>Command', () => {
+  beforeEach(() => {
+    vi.mocked(set<PascalKey>).mockClear();
+  });
+
+  it('calls set<PascalKey> with user input', async () => {
+    vi.mocked(window.showInputBox).mockResolvedValue('value' as any);
+    await capturedCallbacks['jiralens.<commandId>']();
+    expect(set<PascalKey>).toHaveBeenCalledWith('value');
+  });
+
+  it('does nothing when the user dismisses', async () => {
+    vi.mocked(window.showInputBox).mockResolvedValue(undefined as any);
+    await capturedCallbacks['jiralens.<commandId>']();
+    expect(set<PascalKey>).not.toHaveBeenCalled();
+  });
+});
+```
+
+Make sure `window.showInputBox` is present in `test/__mocks__/vscode.ts` — add it if missing:
+
+```typescript
+showInputBox: vi.fn(),
+```
+
+---
+
+## 5. Service integration (CONDITIONAL — if the config is read by `src/services/jira.ts` or another service)
+
+- Import the new getter in the service file.
+- Read the config value **at call time** inside the relevant function (not at module initialisation) — this is the existing pattern in `jira.ts` (`getJiraProjectKeys`, `getJiraHost`, `getJiraEmail`, `getJiraBearerToken` are all called inside functions, not cached at the top level).
+- Add or update tests in `test/unit/services/jira.test.ts`:
+  - Add the getter to the `vi.mock('../../../src/configs', …)` factory with a sensible default.
+  - Import the mock via the existing `import { … } from '../../../src/configs'` static import at the top (this test file uses static imports, unlike commands.test.ts).
+  - Use `vi.mocked(get<PascalKey>).mockReturnValue(…)` in `beforeEach` or individual tests.
+  - Test each branch the config value controls.
+
+---
+
+## 6. Inline message integration (CONDITIONAL — if the config controls what appears in the inline decoration)
+
+- Import the getter in `src/components/InlineMessageController.ts`.
+- Add a guard inside `getInlineMessage()`, following the pattern of existing guards. Note that some guards involve additional computation before the push (e.g. looking up a key, formatting a timestamp) — the guard wraps all that work, not just the `messages.push`:
+
+```typescript
+if (get<PascalKey>()) {
+  // compute value if needed, then:
+  messages.push(value);
+}
+```
+
+`getInlineMessage()` also has an early-return guard at the top (`if (gitBlameInfo.author === 'Not Committed Yet') return …`) — ensure your guard comes after that.
+
+---
+
+## 7. Documentation (MANDATORY for user-facing configs)
+
+### `README.md`
+- Add or update a subsection under **Extension Setup**.
+- If a new command was added, list it in the **Comprehensive Commands** code block.
+- If the TOC needs a new entry, add it.
+
+### `CLAUDE.md`
+- Add a row to the **Configuration Keys** table:
+  ```
+  | `<keyName>` | type | `<default>` | Description |
+  ```
+
+---
+
+## Quick decision guide
+
+| Question                                       | If YES → also update    |
+| ---------------------------------------------- | ----------------------- |
+| Does the config need a UI command?             | §4a, §4b, §4c           |
+| Is the config read by `src/services/jira.ts`?  | §5                      |
+| Does the config control the inline decoration? | §6                      |
+| Is the config part of user-facing setup?       | §7 (README + CLAUDE.md) |
+
+Run `npm run test:unit` after all changes to confirm nothing is broken.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,16 +69,16 @@ test/
 
 ## Configuration Keys (`jiralens.*`)
 
-| Key                        | Type     | Default             | Description                               |
-| -------------------------- | -------- | ------------------- | ----------------------------------------- |
-| `jiraHost`                 | string   | `jira.jiralens.com` | Jira instance host                        |
+| Key                        | Type     | Default             | Description                                                 |
+| -------------------------- | -------- | ------------------- | ----------------------------------------------------------- |
+| `jiraHost`                 | string   | `jira.jiralens.com` | Jira instance host                                          |
 | `jiraEmail`                | string   | `""`                | Email for Jira Cloud basic auth (leave empty for Server/DC) |
 | `jiraBearerToken`          | string   | `""`                | PAT for Jira Server/DC, or API token for Jira Cloud         |
-| `jiraProjectKeys`          | string[] | `[]`                | Project key list for issue key extraction |
-| `inlineCommitter`          | boolean  | `true`              | Show committer in inline message          |
-| `inlineRelativeCommitTime` | boolean  | `true`              | Show relative commit time                 |
-| `inlineJiraIssueKey`       | boolean  | `true`              | Show Jira issue key                       |
-| `inlineCommitMessage`      | boolean  | `false`             | Show commit message                       |
+| `jiraProjectKeys`          | string[] | `[]`                | Project key list for issue key extraction                   |
+| `inlineCommitter`          | boolean  | `true`              | Show committer in inline message                            |
+| `inlineRelativeCommitTime` | boolean  | `true`              | Show relative commit time                                   |
+| `inlineJiraIssueKey`       | boolean  | `true`              | Show Jira issue key                                         |
+| `inlineCommitMessage`      | boolean  | `false`             | Show commit message                                         |
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ test/
 | Key                        | Type     | Default             | Description                               |
 | -------------------------- | -------- | ------------------- | ----------------------------------------- |
 | `jiraHost`                 | string   | `jira.jiralens.com` | Jira instance host                        |
-| `jiraBearerToken`          | string   | `""`                | Personal access token                     |
+| `jiraEmail`                | string   | `""`                | Email for Jira Cloud basic auth (leave empty for Server/DC) |
+| `jiraBearerToken`          | string   | `""`                | PAT for Jira Server/DC, or API token for Jira Cloud         |
 | `jiraProjectKeys`          | string[] | `[]`                | Project key list for issue key extraction |
 | `inlineCommitter`          | boolean  | `true`              | Show committer in inline message          |
 | `inlineRelativeCommitTime` | boolean  | `true`              | Show relative commit time                 |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Encountering challenges or envisioning new features? Share your experiences and 
   - [Comprehensive Commands](#comprehensive-commands 'Jump to Comprehensive Commands')
 - [Extension Setup](#extension-setup 'Jump to Extension Setup')
   - [Jira Host](#jira-host 'Jump to Jira Host')
-  - [Bearer Token (Personal Access Token)](#bearer-token-personal-access-token 'Jump to Bearer Token (Personal Access Token)')
+  - [Authentication](#authentication 'Jump to Authentication')
+    - [Jira Cloud](#jira-cloud 'Jump to Jira Cloud')
+    - [Jira Server / Data Center](#jira-server--data-center 'Jump to Jira Server / Data Center')
   - [Project Keys](#project-keys 'Jump to Project Keys')
 - [Known Issues](#known-issues 'Jump to Known Issues')
 
@@ -76,7 +78,8 @@ Easily tailor the extension settings to suit your preferences with a simple and 
 // Type VS Code commands using: Ctrl/Command + Shift + P
 // Available commands:
 Set the Jira Host
-Set the Bearer Token (Personal Access Token) for Jira Authentication
+Set the Jira Email (Jira Cloud only)
+Set the API Token / Personal Access Token for Jira Authentication
 Add a Jira Project Key
 Delete a Jira Project Key
 Set Whether to Show the Committer in Inline Message
@@ -87,7 +90,7 @@ Set Whether to Show the Commit Message in Inline Message
 
 ## Extension Setup
 
-To ensure proper functionality, JiraLens requires the Jira host, the Jira authentication token, and project keys to be configured. Additionally, ensure Jira issue keys are included in commit messages, as they are extracted from there.
+To ensure proper functionality, JiraLens requires the Jira host, authentication credentials, and project keys to be configured. Additionally, ensure Jira issue keys are included in commit messages, as they are extracted from there.
 
 You can customize the extension settings either using the VS Code settings editor or by utilizing the commands mentioned above.
 
@@ -97,9 +100,23 @@ You can customize the extension settings either using the VS Code settings edito
 
 If your Jira address begins with `https://jira.jiralens.com/...`, then set the Jira host as `jira.jiralens.com`.
 
-### Bearer Token (Personal Access Token)
+### Authentication
 
-Navigate to your Jira profile page, access the Personal Access Tokens tab, and generate a token by clicking the corresponding button.
+JiraLens supports both **Jira Cloud** and **Jira Server / Data Center**. The authentication method differs between them.
+
+#### Jira Cloud
+
+Jira Cloud uses email + API token authentication.
+
+1. Set your **Jira Email** (`jiralens.jiraEmail`) to the email address associated with your Atlassian account.
+2. Generate an API token at [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens) and set it as the **API Token** (`jiralens.jiraBearerToken`).
+
+#### Jira Server / Data Center
+
+Jira Server and Data Center use a Personal Access Token (PAT).
+
+1. Leave **Jira Email** (`jiralens.jiraEmail`) empty.
+2. Navigate to your Jira profile page, open the **Personal Access Tokens** tab, and generate a token. Set it as the **API Token / Personal Access Token** (`jiralens.jiraBearerToken`).
 
 ### Project Keys
 

--- a/package.json
+++ b/package.json
@@ -38,10 +38,15 @@
           "default": "jira.jiralens.com",
           "description": "The Jira host."
         },
+        "jiralens.jiraEmail": {
+          "type": "string",
+          "default": "",
+          "description": "The email address for Jira Cloud authentication. Leave empty when using Jira Server or Data Center."
+        },
         "jiralens.jiraBearerToken": {
           "type": "string",
           "default": "",
-          "description": "The bearer token (personal access token) for Jira authentication."
+          "description": "The personal access token for Jira Server/Data Center, or the API token for Jira Cloud (used together with jiraEmail)."
         },
         "jiralens.jiraProjectKeys": {
           "type": "array",
@@ -98,8 +103,12 @@
         "title": "Set the Jira Host"
       },
       {
+        "command": "jiralens.setJiraEmail",
+        "title": "Set the Jira Email (Jira Cloud only)"
+      },
+      {
         "command": "jiralens.setJiraBearerToken",
-        "title": "Set the Bearer Token (Personal Access Token) for Jira Authentication"
+        "title": "Set the API Token / Personal Access Token for Jira Authentication"
       },
       {
         "command": "jiralens.addJiraProjectKey",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,8 +4,10 @@ import {
   addJiraProjectKey,
   deleteJiraProjectKey,
   getJiraBearerToken,
+  getJiraEmail,
   getJiraHost,
   setJiraBearerToken,
+  setJiraEmail,
   setJiraHost,
   setShowInlineCommitMessage,
   setShowInlineCommitter,
@@ -18,6 +20,7 @@ import { isValidUrl } from './utils';
 // The command IDs here must match the command field in package.json
 // Commands to modify extension configurations
 const SET_JIRA_HOST = 'jiralens.setJiraHost';
+const SET_JIRA_EMAIL = 'jiralens.setJiraEmail';
 const SET_JIRA_BEARER_TOKEN = 'jiralens.setJiraBearerToken';
 const ADD_JIRA_PROJECT_KEY = 'jiralens.addJiraProjectKey';
 const DELETE_JIRA_PROJECT_KEY = 'jiralens.deleteJiraProjectKey';
@@ -49,6 +52,26 @@ function registerSetJiraHostCommand(): vscode.Disposable {
   });
 }
 
+function registerSetJiraEmailCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(SET_JIRA_EMAIL, async () => {
+    const emailInput = await vscode.window.showInputBox({
+      prompt:
+        'Enter your Jira Cloud email address (leave empty for Jira Server/Data Center):',
+      placeHolder: 'user@example.com',
+      value: getJiraEmail()
+    });
+    if (emailInput === undefined) {
+      return;
+    }
+    await setJiraEmail(emailInput);
+    vscode.window.showInformationMessage(
+      emailInput
+        ? `Updated the Jira email to: ${emailInput}`
+        : 'Cleared the Jira email (using bearer token auth).'
+    );
+  });
+}
+
 function registerSetJiraBearerTokenCommand(): vscode.Disposable {
   return vscode.commands.registerCommand(SET_JIRA_BEARER_TOKEN, async () => {
     if (!getJiraHost()) {
@@ -56,8 +79,9 @@ function registerSetJiraBearerTokenCommand(): vscode.Disposable {
       return;
     }
     const tokenInput = await vscode.window.showInputBox({
-      prompt:
-        'Enter the bearer token (personal access token) for Jira authentication:',
+      prompt: getJiraEmail()
+        ? 'Enter the API token for Jira Cloud authentication:'
+        : 'Enter the personal access token for Jira Server/Data Center authentication:',
       placeHolder: '',
       value: getJiraBearerToken()
     });
@@ -70,7 +94,7 @@ function registerSetJiraBearerTokenCommand(): vscode.Disposable {
     }
     await setJiraBearerToken(tokenInput);
     vscode.window.showInformationMessage(
-      'Successfully updated the bearer token.'
+      'Successfully updated the authentication token.'
     );
   });
 }
@@ -170,6 +194,7 @@ export default function registerCommands(
 ): void {
   context.subscriptions.push(
     registerSetJiraHostCommand(),
+    registerSetJiraEmailCommand(),
     registerSetJiraBearerTokenCommand(),
     registerAddJiraProjectKeyCommand(),
     registerDeleteJiraProjectKeyCommand(),

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -21,6 +21,25 @@ export async function setJiraHost(host: string): Promise<boolean> {
   }
 }
 
+// jiralens.jiraEmail
+export function getJiraEmail(): string {
+  return wsConfig.get<string>('jiraEmail') ?? '';
+}
+export async function setJiraEmail(email: string): Promise<boolean> {
+  try {
+    await wsConfig.update(
+      'jiraEmail',
+      email,
+      vscode.ConfigurationTarget.Global
+    );
+    syncWorkspaceConfiguration();
+    return true;
+  } catch (error) {
+    vscode.window.showErrorMessage(`Failed to update the Jira email: ${error}`);
+    return false;
+  }
+}
+
 // jiralens.jiraBearerToken
 export function getJiraBearerToken(): string {
   return wsConfig.get<string>('jiraBearerToken') ?? '';

--- a/src/services/jira.ts
+++ b/src/services/jira.ts
@@ -7,6 +7,7 @@ import TurndownService from 'turndown';
 
 import {
   getJiraBearerToken,
+  getJiraEmail,
   getJiraHost,
   getJiraProjectKeys
 } from '../configs';
@@ -44,13 +45,25 @@ export function getJiraQueryUrl(key: string, value: string): string {
 
 export function isValidJiraBearerToken(token: string): boolean {
   try {
-    new JiraApi({
-      protocol: 'https',
-      host: getJiraHost(),
-      apiVersion: '2',
-      strictSSL: true,
-      bearer: token
-    });
+    const email = getJiraEmail();
+    new JiraApi(
+      email
+        ? {
+            protocol: 'https',
+            host: getJiraHost(),
+            apiVersion: '2',
+            strictSSL: true,
+            username: email,
+            password: token
+          }
+        : {
+            protocol: 'https',
+            host: getJiraHost(),
+            apiVersion: '2',
+            strictSSL: true,
+            bearer: token
+          }
+    );
     return true;
   } catch (error) {
     return false;
@@ -60,13 +73,26 @@ export function isValidJiraBearerToken(token: string): boolean {
 export async function getJiraIssueContent(
   jiraIssueKey: string
 ): Promise<JiraApi.JsonResponse | undefined> {
-  const jira = new JiraApi({
-    protocol: 'https',
-    host: getJiraHost(),
-    apiVersion: '2',
-    strictSSL: true,
-    bearer: getJiraBearerToken()
-  });
+  const email = getJiraEmail();
+  const token = getJiraBearerToken();
+  const jira = new JiraApi(
+    email
+      ? {
+          protocol: 'https',
+          host: getJiraHost(),
+          apiVersion: '2',
+          strictSSL: true,
+          username: email,
+          password: token
+        }
+      : {
+          protocol: 'https',
+          host: getJiraHost(),
+          apiVersion: '2',
+          strictSSL: true,
+          bearer: token
+        }
+  );
   const issueContent = await jira.findIssue(jiraIssueKey);
   return issueContent;
 }

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -13,6 +13,7 @@ export const window = {
   showErrorMessage: vi.fn(),
   showWarningMessage: vi.fn(),
   showInformationMessage: vi.fn(),
+  showInputBox: vi.fn(),
   showQuickPick: vi.fn()
 };
 

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -3,9 +3,11 @@ import { commands, window } from 'vscode';
 
 vi.mock('../../src/configs', () => ({
   getJiraHost: vi.fn().mockReturnValue('jira.example.com'),
+  getJiraEmail: vi.fn().mockReturnValue(''),
   getJiraBearerToken: vi.fn().mockReturnValue('token'),
   getJiraProjectKeys: vi.fn().mockReturnValue([]),
   setJiraHost: vi.fn().mockResolvedValue(true),
+  setJiraEmail: vi.fn().mockResolvedValue(true),
   setJiraBearerToken: vi.fn().mockResolvedValue(true),
   addJiraProjectKey: vi.fn().mockResolvedValue(true),
   deleteJiraProjectKey: vi.fn().mockResolvedValue(true),
@@ -26,9 +28,13 @@ vi.mock('../../src/utils', () => ({
 
 // Import after mocks are set up
 const { default: registerCommands } = await import('../../src/commands');
-const { setShowInlineJiraIssueKey, setShowInlineCommitMessage } = await import(
-  '../../src/configs'
-);
+const {
+  getJiraEmail,
+  setJiraEmail,
+  setJiraBearerToken,
+  setShowInlineJiraIssueKey,
+  setShowInlineCommitMessage
+} = await import('../../src/configs');
 
 const mockContext = { subscriptions: { push: vi.fn() } } as any;
 
@@ -42,6 +48,67 @@ vi.mocked(commands.registerCommand).mockImplementation(
 );
 
 registerCommands(mockContext);
+
+describe('registerSetJiraEmailCommand', () => {
+  beforeEach(() => {
+    vi.mocked(setJiraEmail).mockClear();
+  });
+
+  it('calls setJiraEmail with the entered email', async () => {
+    vi.mocked(window.showInputBox).mockResolvedValue('user@example.com' as any);
+    await capturedCallbacks['jiralens.setJiraEmail']();
+    expect(setJiraEmail).toHaveBeenCalledWith('user@example.com');
+  });
+
+  it('calls setJiraEmail with empty string to clear the email', async () => {
+    vi.mocked(window.showInputBox).mockResolvedValue('' as any);
+    await capturedCallbacks['jiralens.setJiraEmail']();
+    expect(setJiraEmail).toHaveBeenCalledWith('');
+  });
+
+  it('does nothing when the user dismisses the input box', async () => {
+    vi.mocked(window.showInputBox).mockResolvedValue(undefined as any);
+    await capturedCallbacks['jiralens.setJiraEmail']();
+    expect(setJiraEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerSetJiraBearerTokenCommand', () => {
+  beforeEach(() => {
+    vi.mocked(setJiraBearerToken).mockClear();
+    vi.mocked(getJiraEmail).mockReturnValue('');
+  });
+
+  it('uses the Server/DC prompt when email is not configured', async () => {
+    vi.mocked(getJiraEmail).mockReturnValue('');
+    vi.mocked(window.showInputBox).mockResolvedValue('my-pat' as any);
+    await capturedCallbacks['jiralens.setJiraBearerToken']();
+    expect(window.showInputBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('personal access token')
+      })
+    );
+    expect(setJiraBearerToken).toHaveBeenCalledWith('my-pat');
+  });
+
+  it('uses the Cloud prompt when email is configured', async () => {
+    vi.mocked(getJiraEmail).mockReturnValue('user@example.com');
+    vi.mocked(window.showInputBox).mockResolvedValue('my-api-token' as any);
+    await capturedCallbacks['jiralens.setJiraBearerToken']();
+    expect(window.showInputBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('API token')
+      })
+    );
+    expect(setJiraBearerToken).toHaveBeenCalledWith('my-api-token');
+  });
+
+  it('does nothing when the user dismisses the input box', async () => {
+    vi.mocked(window.showInputBox).mockResolvedValue(undefined as any);
+    await capturedCallbacks['jiralens.setJiraBearerToken']();
+    expect(setJiraBearerToken).not.toHaveBeenCalled();
+  });
+});
 
 describe('registerSetShowJiraIssueKeyCommand', () => {
   beforeEach(() => {

--- a/test/unit/configs.test.ts
+++ b/test/unit/configs.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { workspace } from 'vscode';
 
 import {
+  getJiraEmail,
   getJiraProjectKeys,
   getShowInlineCommitMessage,
   getShowInlineCommitter,
@@ -15,6 +16,18 @@ const mockGet = vi.mocked(workspace.getConfiguration('jiralens').get);
 
 beforeEach(() => {
   mockGet.mockReset();
+});
+
+describe('getJiraEmail', () => {
+  it('returns the configured email', () => {
+    mockGet.mockReturnValue('user@example.com');
+    expect(getJiraEmail()).toBe('user@example.com');
+  });
+
+  it('returns an empty string when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getJiraEmail()).toBe('');
+  });
 });
 
 describe('getJiraProjectKeys', () => {

--- a/test/unit/services/jira.test.ts
+++ b/test/unit/services/jira.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../../../src/configs', () => ({
   getJiraHost: vi.fn().mockReturnValue('jira.example.com'),
   getJiraProjectKeys: vi.fn().mockReturnValue(['JRL', 'ABC']),
-  getJiraBearerToken: vi.fn().mockReturnValue('test-token')
+  getJiraBearerToken: vi.fn().mockReturnValue('test-token'),
+  getJiraEmail: vi.fn().mockReturnValue('')
 }));
 
 const { MockJiraApi, mockFindIssue } = vi.hoisted(() => {
@@ -16,7 +17,11 @@ const { MockJiraApi, mockFindIssue } = vi.hoisted(() => {
 });
 vi.mock('jira-client', () => ({ default: MockJiraApi }));
 
-import { getJiraHost, getJiraProjectKeys } from '../../../src/configs';
+import {
+  getJiraEmail,
+  getJiraHost,
+  getJiraProjectKeys
+} from '../../../src/configs';
 import {
   convertJiraMarkdownToHtml,
   convertJiraMarkdownToNormalMarkdown,
@@ -216,6 +221,7 @@ describe('getJiraIssueContent', () => {
     MockJiraApi.mockImplementation(function () {
       return { findIssue: mockFindIssue };
     });
+    vi.mocked(getJiraEmail).mockReturnValue('');
   });
 
   it('returns the issue data resolved by findIssue', async () => {
@@ -232,7 +238,7 @@ describe('getJiraIssueContent', () => {
     expect(mockFindIssue).toHaveBeenCalledWith('JRL-321');
   });
 
-  it('constructs JiraApi with the host and token from config', async () => {
+  it('constructs JiraApi with bearer token when email is not configured (Jira Server/DC)', async () => {
     mockFindIssue.mockResolvedValue(mockIssue1);
     await getJiraIssueContent('JRL-001');
     expect(MockJiraApi).toHaveBeenCalledWith(
@@ -241,6 +247,21 @@ describe('getJiraIssueContent', () => {
         host: 'jira.example.com',
         apiVersion: '2',
         bearer: 'test-token'
+      })
+    );
+  });
+
+  it('constructs JiraApi with basic auth when email is configured (Jira Cloud)', async () => {
+    vi.mocked(getJiraEmail).mockReturnValue('user@example.com');
+    mockFindIssue.mockResolvedValue(mockIssue1);
+    await getJiraIssueContent('JRL-001');
+    expect(MockJiraApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protocol: 'https',
+        host: 'jira.example.com',
+        apiVersion: '2',
+        username: 'user@example.com',
+        password: 'test-token'
       })
     );
   });


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes and explain why they are necessary. -->

To resolve https://github.com/JinZihang/vscode-jiralens/issues/53.

The extension only supported bearer token auth (Jira Server/Data Center PATs). Jira Cloud requires basic auth (email + API token) — that's what causes "Failed to parse Connect Session Auth Token".

To consume the fix, users using Jira Cloud need to set jiralens.jiraEmail to their Jira Cloud email.

## Previous Behavior

<!-- Describe the previous behavior or state before your changes. -->

## Current Behavior

<!-- Explain the current behavior or state after your changes. -->

# Checklist

- [X] No commit includes credentials or sensitive information
- [X] Changes have been tested locally
- [X] Relevant documentations have been updated, or documentation updates are not applicable for this change
