### PR TITLE
perf: add in-memory caches for git blame, Jira issues, and markdown conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,19 +72,24 @@ test/
 - **Config layer**: All reads/writes to `vscode.workspace.getConfiguration('jiralens')` go through `src/configs.ts`. Call `syncWorkspaceConfiguration()` after any write to refresh the module-level cache.
 - **Jira API call**: `fetchJiraIssue()` in `src/services/jira.ts` makes a single `GET /rest/api/2/issue/{key}` call using the Node.js global `fetch`. Auth is `Authorization: Basic base64(email:token)` for Jira Cloud and `Authorization: Bearer {token}` for Jira Server/DC. No external HTTP library is used.
 - **Jira markdown pipeline**: Lives in `src/services/jiraMarkdown.ts`. Jira wiki markup → ProseMirror node (via `@atlaskit/editor-wikimarkup-transformer`) → HTML (via `prosemirror-model` DOMSerializer + jsdom) → normal markdown (via turndown). Re-exported from `jira.ts` for convenience.
+- **In-memory caches**: Three session-scoped caches reduce hot-path overhead. All are module-level Maps that survive for the lifetime of the extension host process.
+  - _Git blame_ (`src/services/git.ts`): `Map<string, GitBlameInfo>` keyed by `"filePath:lineNumber"`. Invalidated for the entire file on every `onDidChangeTextDocument` event via `invalidateGitBlameCache(filePath)` in `extension.ts`. No size cap is enforced — editing patterns keep the map naturally small, and entries are wiped file-by-file on every save.
+  - _Jira issues_ (`src/services/jira.ts`): `Map<string, { promise, timestamp }>` keyed by issue key. The `Promise` itself is stored so concurrent callers for the same key share one in-flight request rather than firing duplicates. TTL is controlled by `jiralens.jiraCacheTtlSeconds` (default 300 s; 0 = session-scoped, never expires). Cleared entirely when `jiraHost`, `jiraBearerToken`, or `jiraEmail` changes in `onDidChangeConfiguration`.
+  - _Markdown conversion_ (`src/services/jiraMarkdown.ts`): Two `Map<string, string>` caches — `_htmlCache` and `_markdownCache` — keyed by raw input string. Both are hard-capped at 200 entries with FIFO eviction via `evictOldest()`. Conversion is deterministic so no TTL is needed; the same markup always produces the same output.
 
 ## Configuration Keys (`jiralens.*`)
 
-| Key                        | Type     | Default             | Description                                                 |
-| -------------------------- | -------- | ------------------- | ----------------------------------------------------------- |
-| `jiraHost`                 | string   | `jira.jiralens.com` | Jira instance host                                          |
-| `jiraEmail`                | string   | `""`                | Email for Jira Cloud basic auth (leave empty for Server/DC) |
-| `jiraBearerToken`          | string   | `""`                | PAT for Jira Server/DC, or API token for Jira Cloud         |
-| `jiraProjectKeys`          | string[] | `[]`                | Project key list for issue key extraction                   |
-| `inlineCommitter`          | boolean  | `true`              | Show committer in inline message                            |
-| `inlineRelativeCommitTime` | boolean  | `true`              | Show relative commit time                                   |
-| `inlineJiraIssueKey`       | boolean  | `true`              | Show Jira issue key                                         |
-| `inlineCommitMessage`      | boolean  | `false`             | Show commit message                                         |
+| Key                        | Type     | Default             | Description                                                                                |
+| -------------------------- | -------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| `jiraHost`                 | string   | `jira.jiralens.com` | Jira instance host                                                                         |
+| `jiraEmail`                | string   | `""`                | Email for Jira Cloud basic auth (leave empty for Server/DC)                                |
+| `jiraBearerToken`          | string   | `""`                | PAT for Jira Server/DC, or API token for Jira Cloud                                        |
+| `jiraProjectKeys`          | string[] | `[]`                | Project key list for issue key extraction                                                  |
+| `inlineCommitter`          | boolean  | `true`              | Show committer in inline message                                                           |
+| `inlineRelativeCommitTime` | boolean  | `true`              | Show relative commit time                                                                  |
+| `inlineJiraIssueKey`       | boolean  | `true`              | Show Jira issue key                                                                        |
+| `inlineCommitMessage`      | boolean  | `false`             | Show commit message                                                                        |
+| `jiraCacheTtlSeconds`      | number   | `300`               | Seconds to keep a fetched Jira issue before re-fetching; `0` = keep for the entire session |
 
 ## Working Practices
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Encountering challenges or envisioning new features? Share your experiences and 
     - [Jira Cloud](#jira-cloud 'Jump to Jira Cloud')
     - [Jira Server / Data Center](#jira-server--data-center 'Jump to Jira Server / Data Center')
   - [Project Keys](#project-keys 'Jump to Project Keys')
+- [Data Caching](#data-caching 'Jump to Data Caching')
+  - [Jira Issue Data](#jira-issue-data 'Jump to Jira Issue Data')
+  - [Git Blame and Markdown Conversion](#git-blame-and-markdown-conversion 'Jump to Git Blame and Markdown Conversion')
 - [Known Issues](#known-issues 'Jump to Known Issues')
 
 ## Introduction
@@ -121,6 +124,29 @@ Jira Server and Data Center use a Personal Access Token (PAT).
 ### Project Keys
 
 Refer to [this documentation](https://support.atlassian.com/jira-software-cloud/docs/what-is-an-issue/) for the definition of Jira issue key and Jira project key. If an issue's key is `JRL-123`, then its corresponding project key is `JRL`.
+
+## Data Caching
+
+JiraLens caches data locally in memory to keep the inline message, hover modal, and sidebar responsive as you navigate your code.
+
+### Jira Issue Data
+
+Fetched Jira issue details are kept in memory and reused for subsequent views of the same issue. By default, a cached issue is considered fresh for **5 minutes** before being re-fetched. You can adjust this in VS Code settings via `jiralens.jiraCacheTtlSeconds`:
+
+- Set a **lower value** to see more up-to-date issue details at the cost of more network requests.
+- Set a **higher value** to reduce network requests; data may be slightly behind what is on Jira.
+- Set to **0** to keep fetched issues for the entire session without ever re-fetching.
+
+The cache is automatically cleared whenever you change your Jira host or authentication credentials, so you will always see data from the correct server with the correct account.
+
+### Git Blame and Markdown Conversion
+
+Git blame results and Jira markup conversions are also cached automatically. These caches have no user-facing setting because they manage themselves safely:
+
+- **Git blame** — Cleared immediately for a file whenever you edit it, so you always see current blame data. There is no risk of stale results because every keystroke that changes a file also clears that file's cached blame entries.
+- **Markdown conversion** — Capped at 200 entries per session. Because the same Jira markup always produces the same output, the result is stored and reused rather than recomputed. 200 entries covers far more than a typical session needs (most developers encounter far fewer than 200 distinct issue descriptions in one sitting), keeping the total memory footprint well under a few megabytes.
+
+If you notice any sluggishness or unexpected memory usage, please [open a GitHub issue](https://github.com/JinZihang/vscode-jiralens/issues) and describe your experience — it helps us tune the caches further.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,12 @@
           "type": "boolean",
           "default": false,
           "description": "Show the commit message in inline message."
+        },
+        "jiralens.jiraCacheTtlSeconds": {
+          "type": "number",
+          "default": 300,
+          "minimum": 0,
+          "description": "How long (in seconds) a fetched Jira issue is kept in memory before being re-fetched from your Jira server. Increase this to reduce network requests; decrease it to see more up-to-date issue details. Set to 0 to keep fetched issues for the entire session without re-fetching. Default: 300 (5 minutes)."
         }
       }
     },

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -16,6 +16,7 @@ let _showInlineJiraIssueKey =
   wsConfig.get<boolean>('inlineJiraIssueKey') ?? true;
 let _showInlineCommitMessage =
   wsConfig.get<boolean>('inlineCommitMessage') ?? false;
+let _jiraCacheTtlSeconds = wsConfig.get<number>('jiraCacheTtlSeconds') ?? 300;
 
 export function syncWorkspaceConfiguration(): void {
   wsConfig = vscode.workspace.getConfiguration('jiralens');
@@ -29,6 +30,7 @@ export function syncWorkspaceConfiguration(): void {
   _showInlineJiraIssueKey = wsConfig.get<boolean>('inlineJiraIssueKey') ?? true;
   _showInlineCommitMessage =
     wsConfig.get<boolean>('inlineCommitMessage') ?? false;
+  _jiraCacheTtlSeconds = wsConfig.get<number>('jiraCacheTtlSeconds') ?? 300;
 }
 
 async function setConfig<T>(
@@ -142,6 +144,11 @@ export async function setShowInlineJiraIssueKey(
 // jiralens.inlineCommitMessage
 export function getShowInlineCommitMessage(): boolean {
   return _showInlineCommitMessage;
+}
+
+// jiralens.jiraCacheTtlSeconds
+export function getJiraCacheTtlSeconds(): number {
+  return _jiraCacheTtlSeconds;
 }
 export async function setShowInlineCommitMessage(
   show: boolean

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,14 @@ import InlineMessageController from './components/InlineMessageController';
 import StatusBarItemController from './components/StatusBarItemController';
 import WebviewController from './components/webview/WebviewController';
 import {
+  getJiraBearerToken,
+  getJiraEmail,
+  getJiraHost,
   getMissingCoreConfigMessages,
   syncWorkspaceConfiguration
 } from './configs';
-import { runGitBlameCommand } from './services/git';
-import { getJiraIssueKey } from './services/jira';
+import { invalidateGitBlameCache, runGitBlameCommand } from './services/git';
+import { getJiraIssueKey, invalidateJiraCache } from './services/jira';
 import { delay } from './utils';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -22,14 +25,23 @@ export function activate(context: vscode.ExtensionContext): void {
 function bindEventListeners(context: vscode.ExtensionContext): void {
   // Debouncing was removed because any interval low enough to feel responsive
   // (< 200 ms) still fires on every key-repeat (~30 ms), while anything higher
-  // makes deliberate navigation feel sluggish. The correct fix is to cache
-  // git-blame results (F2) and Jira responses (F3) so that repeated onChange
-  // calls are cheap Map lookups rather than subprocess spawns and network
-  // requests. A debounce utility is available in utils.ts if needed once the
-  // caches are in place.
+  // makes deliberate navigation feel sluggish. Both git-blame results and Jira
+  // responses are now cached, so repeated onChange calls are cheap Map lookups.
+  // A debounce utility is available in utils.ts if burst-collapse protection is
+  // ever wanted on top of the caches.
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(() => {
+      const prevHost = getJiraHost();
+      const prevToken = getJiraBearerToken();
+      const prevEmail = getJiraEmail();
       syncWorkspaceConfiguration();
+      if (
+        getJiraHost() !== prevHost ||
+        getJiraBearerToken() !== prevToken ||
+        getJiraEmail() !== prevEmail
+      ) {
+        invalidateJiraCache();
+      }
       onChange();
     }),
     // onDidChangeActiveTextEditor    - change of editor
@@ -47,7 +59,10 @@ function bindEventListeners(context: vscode.ExtensionContext): void {
       onChange();
     }),
     vscode.window.onDidChangeTextEditorSelection(onChange),
-    vscode.workspace.onDidChangeTextDocument(onChange)
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      invalidateGitBlameCache(event.document.uri.fsPath);
+      onChange();
+    })
   );
 }
 

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -3,6 +3,20 @@ import * as vscode from 'vscode';
 
 import { GitBlameCommandInfo, GitBlameInfo } from './git.types';
 
+const _gitBlameCache = new Map<string, GitBlameInfo>();
+
+export function invalidateGitBlameCache(filePath: string): void {
+  for (const key of _gitBlameCache.keys()) {
+    if (key.startsWith(`${filePath}:`)) {
+      _gitBlameCache.delete(key);
+    }
+  }
+}
+
+export function clearGitBlameCache(): void {
+  _gitBlameCache.clear();
+}
+
 function parseGitBlameResponse(blame: string): GitBlameInfo {
   const lines = blame.trim().split('\n');
   lines[0] = `commit ${lines[0]}`;
@@ -27,6 +41,17 @@ export async function runGitBlameCommand(): Promise<
   }
   const activeFile = activeEditor.document.uri;
   const activeLineNumber = activeEditor.selection.active.line;
+
+  const cacheKey = `${activeFile.fsPath}:${activeLineNumber}`;
+  const cached = _gitBlameCache.get(cacheKey);
+  if (cached !== undefined) {
+    return {
+      gitBlameInfo: cached,
+      editor: activeEditor,
+      lineNumber: activeLineNumber
+    };
+  }
+
   const commandArguments = [
     'blame',
     '--porcelain',
@@ -43,6 +68,7 @@ export async function runGitBlameCommand(): Promise<
     const gitBlameCommand = cp.spawn('git', commandArguments, commandOptions);
     gitBlameCommand.stdout.on('data', (response) => {
       const gitBlameInfo = parseGitBlameResponse(response.toString());
+      _gitBlameCache.set(cacheKey, gitBlameInfo);
       resolve({
         gitBlameInfo,
         editor: activeEditor,

--- a/src/services/jira.ts
+++ b/src/services/jira.ts
@@ -1,5 +1,6 @@
 import {
   getJiraBearerToken,
+  getJiraCacheTtlSeconds,
   getJiraEmail,
   getJiraHost,
   getJiraProjectKeys
@@ -52,9 +53,30 @@ export function getJiraQueryUrl(key: string, value: string): string {
   return `https://${getJiraHost()}/issues/?jql=${encodeURIComponent(`${key}="${value}"`)}`;
 }
 
+interface JiraCacheEntry {
+  promise: Promise<JiraIssue | undefined>;
+  timestamp: number;
+}
+
+const _jiraCache = new Map<string, JiraCacheEntry>();
+
+export function invalidateJiraCache(): void {
+  _jiraCache.clear();
+}
+
 export async function fetchJiraIssue(
   jiraIssueKey: string
 ): Promise<JiraIssue | undefined> {
+  const ttlMs = getJiraCacheTtlSeconds() * 1000;
+  const entry = _jiraCache.get(jiraIssueKey);
+  if (entry !== undefined) {
+    const isExpired = ttlMs > 0 && Date.now() - entry.timestamp > ttlMs;
+    if (!isExpired) {
+      return entry.promise;
+    }
+    _jiraCache.delete(jiraIssueKey);
+  }
+
   const host = getJiraHost();
   const token = getJiraBearerToken();
   const email = getJiraEmail();
@@ -62,18 +84,25 @@ export async function fetchJiraIssue(
   const authHeader = email
     ? `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`
     : `Bearer ${token}`;
-  try {
-    const response = await fetch(url, {
-      headers: { Authorization: authHeader, Accept: 'application/json' }
-    });
-    if (!response.ok) {
-      throw new Error(
-        `Jira API error: ${response.status} ${response.statusText}`
-      );
+
+  const promise: Promise<JiraIssue | undefined> = (async () => {
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: authHeader, Accept: 'application/json' }
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Jira API error: ${response.status} ${response.statusText}`
+        );
+      }
+      return (await response.json()) as JiraIssue;
+    } catch (error) {
+      console.error(`Failed to fetch Jira issue ${jiraIssueKey}:`, error);
+      _jiraCache.delete(jiraIssueKey);
+      return undefined;
     }
-    return (await response.json()) as JiraIssue;
-  } catch (error) {
-    console.error(`Failed to fetch Jira issue ${jiraIssueKey}:`, error);
-    return undefined;
-  }
+  })();
+
+  _jiraCache.set(jiraIssueKey, { promise, timestamp: Date.now() });
+  return promise;
 }

--- a/src/services/jiraMarkdown.ts
+++ b/src/services/jiraMarkdown.ts
@@ -18,11 +18,32 @@ _turndownService.addRule('strikethrough', {
 const conversionFailureMessage =
   'Encountered an error while converting this Jira markdown to HTML for display. Kindly help us resolve this issue by reporting it <a href="https://github.com/JinZihang/vscode-jiralens/issues/23">here</a>.';
 
+// Conversion is deterministic and can be expensive for large inputs (comments
+// loop, long descriptions). Cap at 200 entries; evict the oldest on overflow.
+const MAX_CACHE_ENTRIES = 200;
+const _htmlCache = new Map<string, string>();
+const _markdownCache = new Map<string, string>();
+
+function evictOldest(cache: Map<string, string>): void {
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    cache.delete(cache.keys().next().value!);
+  }
+}
+
+export function clearMarkdownCache(): void {
+  _htmlCache.clear();
+  _markdownCache.clear();
+}
+
 export function convertJiraMarkdownToHtml(
   markdown: string | null | undefined
 ): string {
   if (!markdown) {
     return '';
+  }
+  const cached = _htmlCache.get(markdown);
+  if (cached !== undefined) {
+    return cached;
   }
   try {
     const pmNode = _transformer.parse(markdown);
@@ -32,7 +53,10 @@ export function convertJiraMarkdownToHtml(
       { document: _document },
       target
     ) as HTMLElement;
-    return html.outerHTML;
+    const result = html.outerHTML;
+    evictOldest(_htmlCache);
+    _htmlCache.set(markdown, result);
+    return result;
   } catch (error) {
     console.debug('Failed to convert Jira markdown to HTML:', markdown, error);
     return conversionFailureMessage;
@@ -42,12 +66,22 @@ export function convertJiraMarkdownToHtml(
 export function convertJiraMarkdownToNormalMarkdown(
   markdown: string | null | undefined
 ): string {
+  if (!markdown) {
+    return '';
+  }
+  const cached = _markdownCache.get(markdown);
+  if (cached !== undefined) {
+    return cached;
+  }
   try {
     const html = convertJiraMarkdownToHtml(markdown);
     if (html === conversionFailureMessage) {
       return 'Encountered an error while converting this Jira markdown to HTML for display. Kindly help us resolve this issue by reporting it [here](https://github.com/JinZihang/vscode-jiralens/issues/23).';
     }
-    return _turndownService.turndown(html);
+    const result = _turndownService.turndown(html);
+    evictOldest(_markdownCache);
+    _markdownCache.set(markdown, result);
+    return result;
   } catch (error) {
     console.debug(
       'Failed to convert Jira markdown to normal markdown:',

--- a/test/unit/configs.test.ts
+++ b/test/unit/configs.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { workspace } from 'vscode';
 
 import {
+  getJiraCacheTtlSeconds,
   getJiraEmail,
   getJiraProjectKeys,
   getMissingCoreConfigMessages,
@@ -189,6 +190,26 @@ describe('getMissingCoreConfigMessages', () => {
     });
     syncWorkspaceConfiguration();
     expect(getMissingCoreConfigMessages()).toHaveLength(3);
+  });
+});
+
+describe('getJiraCacheTtlSeconds', () => {
+  it('returns the configured value', () => {
+    mockGet.mockReturnValue(600);
+    syncWorkspaceConfiguration();
+    expect(getJiraCacheTtlSeconds()).toBe(600);
+  });
+
+  it('returns 0 when set to 0 (no expiry)', () => {
+    mockGet.mockReturnValue(0);
+    syncWorkspaceConfiguration();
+    expect(getJiraCacheTtlSeconds()).toBe(0);
+  });
+
+  it('returns 300 when the setting is undefined', () => {
+    mockGet.mockReturnValue(undefined);
+    syncWorkspaceConfiguration();
+    expect(getJiraCacheTtlSeconds()).toBe(300);
   });
 });
 

--- a/test/unit/services/git.test.ts
+++ b/test/unit/services/git.test.ts
@@ -8,7 +8,11 @@ vi.mock('child_process', () => ({
 import * as cp from 'child_process';
 import * as vscode from 'vscode';
 
-import { runGitBlameCommand } from '../../../src/services/git';
+import {
+  clearGitBlameCache,
+  invalidateGitBlameCache,
+  runGitBlameCommand
+} from '../../../src/services/git';
 
 // A realistic git blame --porcelain output for a single line
 const MOCK_BLAME_PORCELAIN_OUTPUT = `abc123def456abc123def456abc123def456abc1 1 1 1
@@ -39,6 +43,7 @@ function createMockTextEditor(fsPath: string, line: number) {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  clearGitBlameCache();
 });
 
 afterEach(() => {
@@ -111,6 +116,57 @@ describe('runGitBlameCommand', () => {
       'feat: JRL-123 add the status bar item'
     );
     expect(result!.gitBlameInfo.filename).toBe('src/extension.ts');
+  });
+
+  it('returns cached result on repeated call for same file and line without spawning git again', async () => {
+    const mockProcess = createMockChildProcess();
+    vi.mocked(cp.spawn).mockReturnValue(
+      mockProcess as ReturnType<typeof cp.spawn>
+    );
+    (vscode.window as unknown as Record<string, unknown>).activeTextEditor =
+      createMockTextEditor('/workspace/src/extension.ts', 10);
+    vi.mocked(vscode.workspace.getWorkspaceFolder).mockReturnValue({
+      uri: { fsPath: '/workspace' }
+    } as ReturnType<typeof vscode.workspace.getWorkspaceFolder>);
+
+    const firstPromise = runGitBlameCommand();
+    await Promise.resolve();
+    mockProcess.stdout.emit('data', Buffer.from(MOCK_BLAME_PORCELAIN_OUTPUT));
+    const firstResult = await firstPromise;
+
+    const secondResult = await runGitBlameCommand();
+
+    expect(cp.spawn).toHaveBeenCalledTimes(1);
+    expect(secondResult?.gitBlameInfo.summary).toBe(
+      firstResult?.gitBlameInfo.summary
+    );
+  });
+
+  it('spawns git again after the cache entry for the file is invalidated', async () => {
+    const mockProcess1 = createMockChildProcess();
+    const mockProcess2 = createMockChildProcess();
+    vi.mocked(cp.spawn)
+      .mockReturnValueOnce(mockProcess1 as ReturnType<typeof cp.spawn>)
+      .mockReturnValueOnce(mockProcess2 as ReturnType<typeof cp.spawn>);
+    (vscode.window as unknown as Record<string, unknown>).activeTextEditor =
+      createMockTextEditor('/workspace/src/extension.ts', 11);
+    vi.mocked(vscode.workspace.getWorkspaceFolder).mockReturnValue({
+      uri: { fsPath: '/workspace' }
+    } as ReturnType<typeof vscode.workspace.getWorkspaceFolder>);
+
+    const firstPromise = runGitBlameCommand();
+    await Promise.resolve();
+    mockProcess1.stdout.emit('data', Buffer.from(MOCK_BLAME_PORCELAIN_OUTPUT));
+    await firstPromise;
+
+    invalidateGitBlameCache('/workspace/src/extension.ts');
+
+    const secondPromise = runGitBlameCommand();
+    await Promise.resolve();
+    mockProcess2.stdout.emit('data', Buffer.from(MOCK_BLAME_PORCELAIN_OUTPUT));
+    await secondPromise;
+
+    expect(cp.spawn).toHaveBeenCalledTimes(2);
   });
 
   it('rejects when git emits a stderr error', async () => {

--- a/test/unit/services/jira.test.ts
+++ b/test/unit/services/jira.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { clearMarkdownCache } from '../../../src/services/jiraMarkdown';
+
 // Mock the configs module so jira.ts pure functions can be tested in isolation
 vi.mock('../../../src/configs', () => ({
   getJiraHost: vi.fn().mockReturnValue('jira.example.com'),
   getJiraProjectKeys: vi.fn().mockReturnValue(['JRL', 'ABC']),
   getJiraBearerToken: vi.fn().mockReturnValue('test-token'),
-  getJiraEmail: vi.fn().mockReturnValue('')
+  getJiraEmail: vi.fn().mockReturnValue(''),
+  getJiraCacheTtlSeconds: vi.fn().mockReturnValue(300)
 }));
 
 const mockFetch = vi.fn();
@@ -13,6 +16,7 @@ vi.stubGlobal('fetch', mockFetch);
 
 import {
   getJiraBearerToken,
+  getJiraCacheTtlSeconds,
   getJiraEmail,
   getJiraHost,
   getJiraProjectKeys
@@ -25,10 +29,15 @@ import {
   getJiraIssueUrl,
   getJiraProfileUrl,
   getJiraQueryUrl,
+  invalidateJiraCache,
   isValidJiraProjectKey
 } from '../../../src/services/jira';
 import mockIssueJRL001 from '../../data/mock_jira_issue_content_1.json';
 import mockIssueJRL321 from '../../data/mock_jira_issue_content_2.json';
+
+beforeEach(() => {
+  clearMarkdownCache();
+});
 
 describe('isValidJiraProjectKey', () => {
   it('returns true for an all-uppercase alphabetic key', () => {
@@ -190,6 +199,12 @@ describe('convertJiraMarkdownToHtml', () => {
   it('returns empty string for empty string input', () => {
     expect(convertJiraMarkdownToHtml('')).toBe('');
   });
+
+  it('returns identical result on repeated call for same input (cache regression guard)', () => {
+    const first = convertJiraMarkdownToHtml('*bold text*');
+    const second = convertJiraMarkdownToHtml('*bold text*');
+    expect(second).toBe(first);
+  });
 });
 
 describe('fetchJiraIssue', () => {
@@ -197,7 +212,9 @@ describe('fetchJiraIssue', () => {
     vi.mocked(getJiraEmail).mockReturnValue('');
     vi.mocked(getJiraHost).mockReturnValue('jira.example.com');
     vi.mocked(getJiraBearerToken).mockReturnValue('test-token');
+    vi.mocked(getJiraCacheTtlSeconds).mockReturnValue(300);
     mockFetch.mockReset();
+    invalidateJiraCache();
   });
 
   it('returns the issue data from the fetch response', async () => {
@@ -271,6 +288,80 @@ describe('fetchJiraIssue', () => {
     const result = await fetchJiraIssue('JRL-001');
     expect(result).toBeUndefined();
   });
+
+  it('returns cached result on repeated call for same key without re-fetching', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockIssueJRL001
+    });
+    const first = await fetchJiraIssue('JRL-001');
+    const second = await fetchJiraIssue('JRL-001');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it('deduplicates concurrent in-flight requests for the same key', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockIssueJRL001
+    });
+    const [first, second] = await Promise.all([
+      fetchJiraIssue('JRL-001'),
+      fetchJiraIssue('JRL-001')
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(mockIssueJRL001);
+    expect(second).toEqual(mockIssueJRL001);
+  });
+
+  it('re-fetches after the TTL expires', async () => {
+    const mockNow = vi.spyOn(Date, 'now');
+    mockNow.mockReturnValue(0);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockIssueJRL001
+    });
+
+    await fetchJiraIssue('JRL-001');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockNow.mockReturnValue(301_000); // 301 s — past the 300 s TTL
+    await fetchJiraIssue('JRL-001');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    mockNow.mockRestore();
+  });
+
+  it('never expires the cache when TTL is 0', async () => {
+    vi.mocked(getJiraCacheTtlSeconds).mockReturnValue(0);
+    const mockNow = vi.spyOn(Date, 'now');
+    mockNow.mockReturnValue(0);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockIssueJRL001
+    });
+
+    await fetchJiraIssue('JRL-001');
+    mockNow.mockReturnValue(999_999_000);
+    await fetchJiraIssue('JRL-001');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockNow.mockRestore();
+  });
+
+  it('retries after a failed fetch (failures are not cached)', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('network failure'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockIssueJRL001
+      });
+    const first = await fetchJiraIssue('JRL-001');
+    const second = await fetchJiraIssue('JRL-001');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(first).toBeUndefined();
+    expect(second).toEqual(mockIssueJRL001);
+  });
 });
 
 describe('convertJiraMarkdownToNormalMarkdown', () => {
@@ -315,5 +406,18 @@ describe('convertJiraMarkdownToNormalMarkdown', () => {
   it('passes plain text through unchanged', () => {
     const result = convertJiraMarkdownToNormalMarkdown('Just plain text');
     expect(result).toContain('Just plain text');
+  });
+
+  it('returns identical result on repeated call for same input (cache regression guard)', () => {
+    const first = convertJiraMarkdownToNormalMarkdown('*bold text*');
+    const second = convertJiraMarkdownToNormalMarkdown('*bold text*');
+    expect(second).toBe(first);
+  });
+
+  it('returns correct result after cache is cleared', () => {
+    const before = convertJiraMarkdownToNormalMarkdown('*bold text*');
+    clearMarkdownCache();
+    const after = convertJiraMarkdownToNormalMarkdown('*bold text*');
+    expect(after).toBe(before);
   });
 });


### PR DESCRIPTION
# Description

Three session-scoped in-memory caches have been added to eliminate the most expensive repeated work on the hot path (`onChange` → git blame → Jira fetch → render). A new user-facing setting controls how long Jira issue data is kept before being re-fetched.

## Previous Behavior

- Every cursor move spawned a fresh `git blame` subprocess, even when navigating back to a line that had already been blamed in the same session.
- Every render of a Jira issue (inline hover, sidebar, tab) triggered a new network request to the Jira API, even for an issue that had just been displayed.
- If the inline message and the webview both needed the same issue simultaneously, two independent network requests went out.
- Jira wiki markup was converted to HTML and then to markdown on every hover and every webview render, even for text that had already been converted earlier in the session.

## Current Behavior

- **Git blame cache**: blame results are stored by `filePath:lineNumber`. Moving the cursor back to a previously visited line is an instant Map lookup. The cache is automatically cleared for a file whenever that file is edited, so blame data is never stale.
- **Jira issue cache**: fetched issues are stored by issue key with a timestamp. Subsequent requests for the same key within the TTL window return the cached result without a network call. Two simultaneous requests for the same key (e.g. from the inline controller and the sidebar) share a single in-flight `Promise` rather than firing two requests. The cache is cleared entirely when the Jira host or authentication credentials change.
- **Markdown conversion cache**: converted HTML and markdown strings are memoised by raw input. The same issue description or comment is only converted once per session, regardless of how many times it is rendered. Each cache is capped at 200 entries with FIFO eviction.
- New setting `jiralens.jiraCacheTtlSeconds` (default `300`) controls how long a fetched Jira issue is kept before being re-fetched. Set to `0` to keep issues for the entire session.

## Cache invalidation summary

| Cache               | What clears it                                                             |
| ------------------- | -------------------------------------------------------------------------- |
| Git blame           | Any edit to the file (`onDidChangeTextDocument`)                           |
| Jira issues         | TTL expiry; or any change to `jiraHost`, `jiraBearerToken`, or `jiraEmail` |
| Markdown conversion | Never within a session (deterministic output; capped at 200 entries)       |

# Checklist

- [x] No commit includes credentials or sensitive information
- [x] Changes have been tested locally
- [x] Relevant documentation has been updated, or documentation updates are not applicable for this change
```
